### PR TITLE
fix(node): publish to /rosout from rclgo nodes

### DIFF
--- a/pkg/rclgo/node_test.go
+++ b/pkg/rclgo/node_test.go
@@ -36,6 +36,38 @@ func requireTopicNamesAndTypes(t *testing.T, node *rclgo.Node, expected map[stri
 	}
 }
 
+// TestNodePublishesRosout is a regression test for
+// https://github.com/MerlinDrones/rclgo/issues/13: rclgo nodes must appear as
+// publishers on /rosout, matching rclcpp/rclpy behavior. Since rcl 9.x (Jazzy)
+// rcl_node_init no longer creates this publisher, so NewNode must create it
+// explicitly.
+func TestNodePublishesRosout(t *testing.T) {
+	setNewDomainID()
+
+	rclctx, err := newDefaultRCLContext()
+	require.NoError(t, err)
+	defer rclctx.Close()
+
+	node, err := rclctx.NewNode("rosout_node", "rosout_test")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	for {
+		topics, err := node.GetTopicNamesAndTypes(true)
+		require.NoError(t, err)
+		if types, ok := topics["/rosout"]; ok {
+			assert.Contains(t, types, "rcl_interfaces/msg/Log")
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("node did not create a /rosout publisher")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
 func TestNodeGetTopicNamesAndTypes(t *testing.T) {
 	setNewDomainID()
 

--- a/pkg/rclgo/rcl.go
+++ b/pkg/rclgo/rcl.go
@@ -21,6 +21,8 @@ package rclgo
 #include <rcl/service.h>
 #include <rcl/timer.h>
 #include <rcl/expand_topic_name.h>
+#include <rcl/logging.h>
+#include <rcl/logging_rosout.h>
 #include <rcl_action/wait.h>
 #include <rcl_yaml_param_parser/parser.h>
 #include <rmw/rmw.h>
@@ -354,6 +356,9 @@ type Node struct {
 	namespace          string
 	fullyQualifiedName string
 	logger             *Logger
+	// rosoutInitialized is true when this node created a /rosout log
+	// publisher that must be finalized when the node is closed.
+	rosoutInitialized bool
 }
 
 func NewNode(nodeName, namespace string) (*Node, error) {
@@ -407,6 +412,22 @@ func (c *Context) NewNode(node_name, namespace string) (node *Node, err error) {
 	}
 	node.logger = GetLogger(C.GoString(loggerName))
 
+	// Create the /rosout log publisher for this node so that its log messages
+	// are visible to /rosout subscribers (e.g. rqt_console), matching the
+	// behavior of rclcpp and rclpy nodes.
+	//
+	// Since rcl 9.x (Jazzy) rcl_node_init no longer creates this publisher
+	// itself; the client library is responsible for it. rcl_node_options
+	// enables rosout by default (enable_rosout = true), so the only remaining
+	// gate is whether rosout logging is enabled globally.
+	if bool(C.rcl_logging_rosout_enabled()) && bool(rcl_node_options.enable_rosout) {
+		rc = C.rcl_logging_rosout_init_publisher_for_node(node.rcl_node_t)
+		if rc != C.RCL_RET_OK {
+			return nil, errorsCastC(rc, "failed to initialize rosout publisher")
+		}
+		node.rosoutInitialized = true
+	}
+
 	c.addResource(node)
 	return node, nil
 }
@@ -421,6 +442,15 @@ func (n *Node) Close() error {
 	n.context.removeResource(n)
 
 	err := n.rosResourceStore.Close()
+
+	// Finalize the /rosout log publisher before finalizing the node, mirroring
+	// the initialization done in NewNode.
+	if n.rosoutInitialized {
+		if rc := C.rcl_logging_rosout_fini_publisher_for_node(n.rcl_node_t); rc != C.RCL_RET_OK {
+			err = errors.Join(err, errorsCastC(rc, "failed to finalize rosout publisher"))
+		}
+		n.rosoutInitialized = false
+	}
 
 	rc := C.rcl_node_fini(n.rcl_node_t)
 	if rc != C.RCL_RET_OK {


### PR DESCRIPTION
## Summary

Fixes #13 — rclgo nodes did not appear as publishers on `/rosout`, so their logs were invisible to `/rosout` subscribers (e.g. `rqt_console`, our `log_forwarder`), unlike C++/Python ROS 2 nodes.

## Root cause

The issue's original hypothesis (custom logging output-handler ordering in `logging.go`) turned out to be a red herring. The real cause is a ROS 2 API change:

**Since rcl 9.x (Jazzy, `ros-jazzy-rcl` 9.2.11), `rcl_node_init` no longer creates the per-node `/rosout` publisher** — that responsibility moved up to the client library. Confirmed against sources:

- `ros2/rcl@9.2.11` `rcl/src/rcl/node.c` includes `logging_rosout.h` but never calls `rcl_logging_rosout_init_publisher_for_node`.
- `ros2/rclcpp@jazzy` `node_base.cpp` (~L115) creates it explicitly after `rcl_node_init`, and finalizes it on destruction (~L129).

rclgo's `NewNode` only called `rcl_node_init` and stopped, so no `/rosout` publisher was ever created.

## Fix

Mirror rclcpp's `node_base.cpp`:

- **`NewNode`**: after a successful `rcl_node_init`, create the `/rosout` publisher via `rcl_logging_rosout_init_publisher_for_node`, gated on `rcl_logging_rosout_enabled() && node_options.enable_rosout`. Track success in a new `Node.rosoutInitialized` field.
- **`Close`**: finalize via `rcl_logging_rosout_fini_publisher_for_node` before `rcl_node_fini`.

Using the stored bool guarantees finalize happens iff init happened; the error/cleanup path is safe against double-finalize since the flag is only set after success.

## Verification

- A standalone program linking the patched package confirmed: before the fix `/rosout` publisher count was 0 after `NewNode` (while a control publisher worked); after the fix the node publishes on `[/rosout]` with count 1.
- Added regression test `TestNodePublishesRosout`.
- `go build ./pkg/rclgo/` passes; gofmt clean.

> Note: the full `go test ./...` requires `ros-jazzy-test-msgs` headers, which weren't installable in my sandbox (no root), so the new test will exercise in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)